### PR TITLE
Remove spacing in version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ dependencies: [
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/Alamofire/WeTransfer-Swift-SDK.git", from: "1.0   ")
+    .package(url: "https://github.com/Alamofire/WeTransfer-Swift-SDK.git", from: "1.0")
 ]
 ```
 


### PR DESCRIPTION
Also the Readme mentions Swift 4.1+ as a requirement, but SwiftPM supports Swift 3. Is that right?